### PR TITLE
Update backend to implement map coordinates

### DIFF
--- a/server/controllers/v1/post.ts
+++ b/server/controllers/v1/post.ts
@@ -1,5 +1,5 @@
 import sequelize from 'sequelize';
-import { Post } from '../../models/post';
+import { latLng, Post } from '../../models/post';
 import { Tag } from '../../models/tags';
 import { UserPostLikes } from '../../models/userPostLikes';
 import { PostTag } from '../../models/PostTags';
@@ -143,6 +143,7 @@ export default class PostController {
         'body',
         'thumbnail',
         'location',
+        'coords',
         'capacity',
         'feedbackScore',
         'UserId',
@@ -315,7 +316,8 @@ export default class PostController {
     body?: string,
     location?: string,
     capacity?: number,
-    tags?: string[]
+    tags?: string[],
+    coords?: latLng
   ): Promise<{
     status: number;
     data: { result?: Post; message?: string };
@@ -325,10 +327,11 @@ export default class PostController {
     }
 
     const post = await this.postsRepo.create({
-      title: title,
-      body: body,
-      location: location,
-      capacity: capacity,
+      title,
+      body,
+      location,
+      capacity,
+      coords,
       UserId: userID,
     });
 
@@ -367,7 +370,8 @@ export default class PostController {
     title?: string,
     body?: string,
     location?: string,
-    capacity?: number
+    capacity?: number,
+    coords?: latLng
   ): Promise<{ status: number; data?: { message?: string; result?: Post } }> {
     const post = await this.postsRepo.findByPk(postID);
 
@@ -377,6 +381,7 @@ export default class PostController {
         post.body = body || post.body;
         post.location = location || post.location;
         post.capacity = capacity || post.capacity;
+        post.coords = coords || post.coords;
         await post.save();
         return { status: 200, data: { result: post } };
       } catch (err) {

--- a/server/controllers/v1/tests/post.test.ts
+++ b/server/controllers/v1/tests/post.test.ts
@@ -145,6 +145,31 @@ describe('Test v1 - Post Controller', () => {
       );
     });
 
+    it('getting a post will include the location and coordinates', async () => {
+      const author = await makeValidUser();
+      const coords = {
+        lat: 59.321312903128301289,
+        lng: -94.2312903128312901212,
+      };
+      const result = await postController.createPost(
+        author.id,
+        'This is a new post!',
+        'This is a new post!This is a new post!',
+        'location',
+        10,
+        [],
+        coords
+      );
+
+      expect(result.status).toBe(200);
+
+      const post = await postController.getPost(
+        author.id,
+        result.data.result!.id
+      );
+      expect(post.data.result?.coords).toEqual(coords);
+    });
+
     it('should error on missing parameters', async () => {
       const author = await makeValidUser();
 

--- a/server/migrations/20210925191009-create-post.ts
+++ b/server/migrations/20210925191009-create-post.ts
@@ -37,6 +37,11 @@ module.exports = {
       coords: {
         // Coordinates to the event (if it is in-person)
         type: DataTypes.JSON,
+        defaultValue: {
+          // if not specified, -1 to indicate online event
+          lat: -1,
+          lng: -1,
+        },
       },
       feedbackScore: {
         /* Post 'score' decreases if it is reported too many times, 

--- a/server/migrations/20210925191009-create-post.ts
+++ b/server/migrations/20210925191009-create-post.ts
@@ -34,6 +34,10 @@ module.exports = {
       capacity: {
         type: DataTypes.INTEGER /* Optional: An event ad can indicate maximum capacity of attendees */,
       },
+      coords: {
+        // Coordinates to the event (if it is in-person)
+        type: DataTypes.JSON,
+      },
       feedbackScore: {
         /* Post 'score' decreases if it is reported too many times, 
                           can increase if liked. Post with score too low is auto removed.*/

--- a/server/models/post.ts
+++ b/server/models/post.ts
@@ -14,6 +14,10 @@ import {
 import { Tag } from './tags';
 import { PostTag } from './PostTags';
 
+export type latLng = {
+  lat: number;
+  lng: number;
+};
 interface PostAttributes {
   id: string;
   title: string;
@@ -21,6 +25,7 @@ interface PostAttributes {
   thumbnail: string;
   location: string;
   capacity: Number;
+  coords: latLng;
   feedbackScore: Number;
   UserId: string;
 }
@@ -28,7 +33,13 @@ interface PostAttributes {
 interface PostCreationAttributes
   extends Optional<
     PostAttributes,
-    'id' | 'thumbnail' | 'location' | 'capacity' | 'feedbackScore' | 'UserId'
+    | 'id'
+    | 'thumbnail'
+    | 'location'
+    | 'coords'
+    | 'capacity'
+    | 'feedbackScore'
+    | 'UserId'
   > {}
 
 export class Post
@@ -41,6 +52,7 @@ export class Post
   thumbnail!: string;
   location!: string;
   capacity!: Number;
+  coords!: latLng;
   feedbackScore!: Number;
   UserId!: string; /* Foreign Key from UserId */
 
@@ -92,6 +104,10 @@ module.exports = (sequelize: Sequelize) => {
       },
       capacity: {
         type: DataTypes.INTEGER /* Optional: An event ad can indicate maximum capacity of attendees */,
+      },
+      coords: {
+        // Coordinates to the event (if it is in-person)
+        type: DataTypes.JSON,
       },
       feedbackScore: {
         /* Post 'score' decreases if it is reported too many times, 

--- a/server/models/post.ts
+++ b/server/models/post.ts
@@ -108,6 +108,11 @@ module.exports = (sequelize: Sequelize) => {
       coords: {
         // Coordinates to the event (if it is in-person)
         type: DataTypes.JSON,
+        defaultValue: {
+          // if not specified, -1 to indicate online event
+          lat: -1,
+          lng: -1,
+        },
       },
       feedbackScore: {
         /* Post 'score' decreases if it is reported too many times, 

--- a/server/models/tests/post.test.ts
+++ b/server/models/tests/post.test.ts
@@ -18,11 +18,13 @@ describe('Post Model', () => {
       expect(author).toBeDefined();
 
       expect(author.userName).toContain('postTester');
+      const coord = { lat: 34.123913028321, lng: -96.123913028321 };
 
       const posted = await makePost(
         author.id,
         'This is a new post!',
-        'Woooo new post new post abcdefghhi!!'
+        'Woooo new post new post abcdefghhi!!',
+        coord
       );
 
       expect(posted).toBeDefined();
@@ -30,6 +32,7 @@ describe('Post Model', () => {
       expect(posted.UserId).toEqual(author.id);
       expect(posted.body).toEqual('Woooo new post new post abcdefghhi!!');
       expect(posted.title).toEqual('This is a new post!');
+      expect(posted.coords).toEqual(coord);
     });
   });
 

--- a/server/models/tests/post.test.ts
+++ b/server/models/tests/post.test.ts
@@ -34,6 +34,26 @@ describe('Post Model', () => {
       expect(posted.title).toEqual('This is a new post!');
       expect(posted.coords).toEqual(coord);
     });
+
+    test('Create a post with no coordinates specified', async () => {
+      const author = await makeUser('postTester', 'poster@mail.utoronto.ca');
+      expect(author).toBeDefined();
+
+      expect(author.userName).toContain('postTester');
+
+      const posted = await makePost(
+        author.id,
+        'This is a new post!',
+        'Woooo new post new post abcdefghhi!!'
+      );
+
+      expect(posted).toBeDefined();
+
+      expect(posted.UserId).toEqual(author.id);
+      expect(posted.body).toEqual('Woooo new post new post abcdefghhi!!');
+      expect(posted.title).toEqual('This is a new post!');
+      expect(posted.coords).toEqual({ lat: -1, lng: -1 });
+    });
   });
 
   describe('Post Validation', () => {

--- a/server/models/tests/testHelpers.ts
+++ b/server/models/tests/testHelpers.ts
@@ -1,5 +1,5 @@
 import db from '../index';
-import { Post } from '../post';
+import { latLng, Post } from '../post';
 import { PostTag } from '../PostTags';
 import { Tag } from '../tags';
 import { User } from '../user';
@@ -63,7 +63,8 @@ title, and body. Return the post on success, or throw an error on failure.
 export async function makePost(
   authorid: string,
   title: string,
-  body: string
+  body: string,
+  coords?: latLng
 ): Promise<Post> {
   return await PostModel.create({
     title: title,
@@ -73,6 +74,7 @@ export async function makePost(
     location: 'toronto',
     thumbnail: 'some-path',
     UserId: authorid,
+    coords,
   });
 }
 

--- a/server/routes/v1/post.ts
+++ b/server/routes/v1/post.ts
@@ -91,7 +91,8 @@ postRouter.post('/', async (req: Request, res: Response) => {
       req.body.body,
       req.body.location,
       req.body.capacity,
-      req.body.tags
+      req.body.tags,
+      req.body.coords
     );
     res.status(result.status).json(result);
   } catch (err) {
@@ -107,7 +108,8 @@ postRouter.put('/:postid', async (req: Request, res: Response) => {
       req.body.title,
       req.body.body,
       req.body.location,
-      req.body.capacity
+      req.body.capacity,
+      req.body.coords
     );
 
     res.status(result.status).json(result);


### PR DESCRIPTION
- Post model has `coords` with type JSON in the format `{lat: number; lng: number}`
- By default coords will be `{lat: -1; lng: -1}`, we can also check this in the frontend. -1 will indicate an online event
- getPost will return the `coords` of a post
- Updated create and update post to handle coords
- Routes have been updated to implement coords

We will be using the `location` to store the exact address of an event in string format (or the location of the online event) and is shown to the user when viewing a post. Coords will store the latitude and longitude and won't be explicitly shown to the user, but instead used to fetch the location with Google Maps API.