### PR TITLE
Setup react router for post viewing

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -94,7 +94,6 @@ function App() {
           <Route path='/' element={<AuthContainer />} />
           <Route path='/dashboard' element={<ProtectedRoute destination={<PostDashboard />} />} />
           <Route path=':postid' element={<ProtectedRoute destination={<ViewPostDialog />} />}  /> 
-          {/*  TODO: PROTECT ROUTE */}
           <Route path='/confirm-account' element={<EmailConfirmContainer />} />
           <Route path='/password-reset' element={<PassResetContainer />} />
         </Routes>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,6 +15,7 @@ import './App.css';
 import { User } from 'models/user';
 
 import ServerApi from './api/v1';
+import ViewPostDialog from './components/ViewPostDialog';
 
 const api = new ServerApi();
 
@@ -43,7 +44,7 @@ const theme = createTheme({
   },
 });
 
-function ProtectedRoute() {
+function ProtectedRoute(props: { destination: JSX.Element }) {
   const [currentUser, setUser] = React.useState({} as User);
   const [isLoading, setLoading] = React.useState(true);
 
@@ -76,7 +77,7 @@ function ProtectedRoute() {
       <UserContext.Provider
         value={{ data: currentUser, setLoading: setLoading }}
       >
-        {<PostDashboard />}
+        {props.destination}
       </UserContext.Provider>
     );
   }
@@ -91,7 +92,9 @@ function App() {
       <BrowserRouter>
         <Routes>
           <Route path='/' element={<AuthContainer />} />
-          <Route path='/dashboard' element={<ProtectedRoute />} />
+          <Route path='/dashboard' element={<ProtectedRoute destination={<PostDashboard />} />} />
+          <Route path=':postid' element={<ProtectedRoute destination={<ViewPostDialog />} />}  /> 
+          {/*  TODO: PROTECT ROUTE */}
           <Route path='/confirm-account' element={<EmailConfirmContainer />} />
           <Route path='/password-reset' element={<PassResetContainer />} />
         </Routes>

--- a/client/src/api/v1/index.ts
+++ b/client/src/api/v1/index.ts
@@ -8,6 +8,7 @@ import { PostTag } from 'models/PostTags';
 export type PostUser = Post & {
   likeCount: number;
   doesUserLike: boolean;
+  createdAt: string;
   User: { id: string; firstName: string; lastName: string };
   Tags: {
     text: string & { PostTags: PostTag }; // sequelize pluarlizes name

--- a/client/src/components/PostPreview.tsx
+++ b/client/src/components/PostPreview.tsx
@@ -11,6 +11,8 @@ import GenerateTags from './Tags';
 import ViewPostDialog from './ViewPostDialog';
 
 import { PostUserPreview } from '../api/v1/index';
+import { useNavigate } from 'react-router-dom';
+import Button from '@mui/material/Button';
 
 /**
  * Return a string of the date relative to now in minutes, hours or days. If the date
@@ -50,11 +52,11 @@ export default function PostPreview(props: {
   // generate tags (if the post has any)
   const tags = (
     <GenerateTags
-      tags={
-        props.postUser.Tags ? props.postUser.Tags.map((t) => t.text) : []
-      }
+      tags={props.postUser.Tags ? props.postUser.Tags.map((t) => t.text) : []}
     />
   );
+
+  const navigate = useNavigate();
 
   return (
     <Grid data-testid='test-postpreview' item xs={12} sm={6} md={4} lg={4}>
@@ -93,11 +95,16 @@ export default function PostPreview(props: {
         </CardContent>
         <CardActions>
           <Stack sx={{ pl: 1 }}>
-            <ViewPostDialog
-              postUser={props.postUser}
-              tags={tags}
-              setOpenedPost={props.setOpenedPost}
-            />
+            <Button
+              data-testid='test-btn-preview'
+              variant='outlined'
+              onClick={() => {
+                navigate(`/${props.postUser.id}`);
+              }}
+              sx={{ mb: 3 }}
+            >
+              Read More
+            </Button>
             {tags}
           </Stack>
         </CardActions>

--- a/client/src/components/ViewPostDialog.tsx
+++ b/client/src/components/ViewPostDialog.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import Button from '@mui/material/Button';
-import Dialog from '@mui/material/Dialog';
 import AppBar from '@mui/material/AppBar';
 import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
 import ArrowBack from '@mui/icons-material/ArrowBack';
-import Slide from '@mui/material/Slide';
-import { TransitionProps } from '@mui/material/transitions';
 import MoreVert from '@mui/icons-material/MoreVert';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
@@ -23,27 +20,18 @@ import Switch from '@mui/material/Switch';
 import { UserContext } from '../App';
 import { LocationMap } from './LocationMap';
 
-import ServerApi, { PostUser, PostUserPreview } from '../api/v1';
+import ServerApi, { PostUser } from '../api/v1';
+import GenerateTags from './Tags';
+import { NavigateFunction, useNavigate, useParams } from 'react-router-dom';
 
 const api = new ServerApi();
-
-const Transition = React.forwardRef(
-  (
-    props: TransitionProps & {
-      children: React.ReactElement;
-    },
-    ref: React.Ref<unknown>
-  ) => {
-    return <Slide direction='up' ref={ref} {...props} />;
-  }
-);
 
 /* Post settings, choosing between deleting, editing or reporting a post. The delete
   and edit options are only shown if the user is authorized. */
 function MoreOptions(props: {
   postID: string;
   isAuth: boolean;
-  closeDialog: Function;
+  useNavigate: NavigateFunction;
 }) {
   const [isOpen, toggleMenu] = React.useState(false);
   const [isAlertOpen, showAlert] = React.useState(false);
@@ -58,7 +46,7 @@ function MoreOptions(props: {
       .deletePost(props.postID)
       .then((res) => {
         if (res.status === 204) {
-          props.closeDialog();
+          props.useNavigate(-1);
         }
       })
       .catch((err) => {
@@ -217,7 +205,7 @@ function LocationHandler(props: {
     props.coords && props.coords.lat !== -1 && props.coords.lng !== -1; // disable google maps with invalid coords
 
   return (
-    <Box sx={{pl: 4, pb: 1}}>
+    <Box sx={{ pl: 4, pb: 1 }}>
       <Typography variant='body2' sx={{ pt: 2 }}>
         Location: {props.location}
         {isOfflineEvent && (
@@ -242,160 +230,154 @@ function LocationHandler(props: {
 }
 
 /* Opens a full screen dialog containing a post. */
-export default function ViewPostDialog(props: {
-  postUser: PostUserPreview;
-  tags: JSX.Element;
-  setOpenedPost: React.Dispatch<React.SetStateAction<boolean>>;
-}) {
-  const [isOpen, toggleDialog] = React.useState(false);
-  const [postData, setData] = React.useState(props.postUser as any as PostUser);
+export default function ViewPostDialog() {
+  const [postData, setData] = React.useState({} as PostUser);
   const [isAuthor, setIsAuthor] = React.useState(false);
+  const [error, toggleError] = React.useState(false);
   const userContext = React.useContext(UserContext);
+  const { postid } = useParams();
+  const navigate = useNavigate();
 
   /* Need to fetch the rest of the post data (or update it incase the post has changed) */
   const fetchData = () => {
     api
-      .fetchPost(props.postUser.id)
+      .fetchPost(postid ? postid : '')
       .then((res) => {
         if (res.data && res.data.data && res.data.data.result) {
           setData(res.data.data.result);
           if (userContext.data) {
-            setIsAuthor(userContext.data.id === props.postUser.User.id);
+            setIsAuthor(userContext.data.id === res.data.data.result.User.id);
+            toggleError(false);
           }
         }
       })
-      .catch((err) => console.error(`Error making post ${err}`));
+      .catch((err) => {
+        console.error(`Error fetching post ${err}`);
+        toggleError(true);
+      });
   };
 
   React.useEffect(() => {
-    /* Fetch incase data has changed / post was edited */
-    if (isOpen) {
-      const interval = setInterval(() => {
-        fetchData();
-      }, 500);
-      return () => clearInterval(interval);
+    // Fetch data (on initiual load)
+    // Prevent fetching again if an error occurred
+    if (!postData.User && !error) {
+      fetchData();
     }
   });
 
-  const closeDialog = () => {
-    props.setOpenedPost(false);
-    toggleDialog(false);
-  };
+  React.useEffect(() => {
+    /* Fetch incase data has changed / post was edited */
+    const interval = setInterval(() => {
+      fetchData();
+    }, 5000);
+    return () => clearInterval(interval);
+  });
 
-  if (!postData || !postData.User) {
-    return <></>;
+
+  if (error) {
+    return <><h1>The post you are looking for may have been deleted. </h1> <a href='/dashboard'>Go back</a> </>;
+  }
+  else if (!postData || !postData.User) {
+    return <h1>Loading..</h1>;
   }
 
   return (
     <>
-      <Button
-        data-testid='test-btn-preview'
-        variant='outlined'
-        onClick={() => {
-          toggleDialog(true);
-          props.setOpenedPost(true);
-          fetchData();
-        }}
-        sx={{ mb: 3 }}
-      >
-        Read More
-      </Button>
-      <Dialog
-        fullScreen
-        open={isOpen}
-        onClose={closeDialog}
-        TransitionComponent={Transition}
-        data-testid='test-post-dialog'
-        aria-label='post-dialog'
-        id={postData.id}
-      >
-        <AppBar sx={{ position: 'relative' }}>
-          <IconButton
-            data-testid='test-btn-close'
-            edge='start'
-            color='inherit'
-            onClick={closeDialog}
-            aria-label='close'
-          >
-            <ArrowBack />
-          </IconButton>
-        </AppBar>
+      <AppBar sx={{ position: 'relative' }}>
+        <IconButton
+          data-testid='test-btn-close'
+          edge='start'
+          color='inherit'
+          onClick={() => {
+            navigate(-1);
+          }}
+          aria-label='close'
+        >
+          <ArrowBack />
+        </IconButton>
+      </AppBar>
 
-        {/* Title and Options (3 dots) */}
-        <Grid>
-          <Stack direction='row' sx={{ pt: 5, pl: 4 }}>
-            <Grid item xs={11}>
-              <Typography variant='h5' style={{ wordWrap: 'break-word' }}>
-                {postData.title}
-              </Typography>
-            </Grid>
-            <MoreOptions
-              postID={postData.id}
-              isAuth={isAuthor}
-              closeDialog={closeDialog}
-            />
-          </Stack>
-        </Grid>
-        {/* Top information (author, date, tags..) */}
-        <Stack sx={{ pl: 4 }}>
-          <Typography variant='body2' sx={{ mb: 1, mt: 0.5 }}>
-            Posted on {new Date(props.postUser.createdAt).toString()} by{' '}
-            {postData.User.firstName} {postData.User.lastName}
-          </Typography>
-          {props.tags}
+      {/* Title and Options (3 dots) */}
+      <Grid>
+        <Stack direction='row' sx={{ pt: 5, pl: 4 }}>
+          <Grid item xs={11}>
+            <Typography variant='h5' style={{ wordWrap: 'break-word' }}>
+              {postData.title}
+            </Typography>
+          </Grid>
+          <MoreOptions
+            postID={postData.id}
+            isAuth={isAuthor}
+            useNavigate={navigate}
+          />
         </Stack>
+      </Grid>
+      {/* Top information (author, date, tags..) */}
+      <Stack sx={{ pl: 4 }}>
+        <Typography variant='body2' sx={{ mb: 1, mt: 0.5 }}>
+          Posted on {new Date(postData.createdAt).toString()} by{' '}
+          {postData.User.firstName} {postData.User.lastName}
+        </Typography>
+        {
+          <GenerateTags
+            tags={postData.Tags ? postData.Tags.map((t) => t.text) : []}
+          />
+        }
+      </Stack>
 
-        {/* Post image and body */}
-        <Stack sx={{ pl: 4 }}>
-          <Box
-            style={{
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}
-          >
-            <img
-              // TODO src={props.postUser.thumbnail}
-              src='https://i.imgur.com/8EYKtwP.png'
-              alt='Thumbnail'
-              height='400px'
-              width='400px'
-            />
-          </Box>
-          <Typography
-            variant='body1'
-            sx={{ px: 4, py: 1, pb: 4 }}
-            style={{ wordWrap: 'break-word' }}
-          >
-            {postData.body}
-          </Typography>
-          <Stack direction='row' sx={{ px: 4, pb: 5 }}>
-            {Number(postData.capacity) > 0 ? (
-              <CapacityBar maxCapacity={Number(postData.capacity)} />
-            ) : (
-              <></>
-            )}
-            <LikeButton numLikes={Number(postData.feedbackScore)} />
-          </Stack>
-            <LocationHandler coords={postData.coords} location={postData.location} />
+      {/* Post image and body */}
+      <Stack sx={{ pl: 4 }}>
+        <Box
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+        >
+          <img
+            // TODO src={props.postUser.thumbnail}
+            src='https://i.imgur.com/8EYKtwP.png'
+            alt='Thumbnail'
+            height='400px'
+            width='400px'
+          />
+        </Box>
+        <Typography
+          variant='body1'
+          sx={{ px: 4, py: 1, pb: 4 }}
+          style={{ wordWrap: 'break-word' }}
+        >
+          {postData.body}
+        </Typography>
+        <Stack direction='row' sx={{ px: 4, pb: 5 }}>
+          {Number(postData.capacity) > 0 ? (
+            <CapacityBar maxCapacity={Number(postData.capacity)} />
+          ) : (
+            <></>
+          )}
+          <LikeButton numLikes={Number(postData.feedbackScore)} />
         </Stack>
+        <LocationHandler
+          coords={postData.coords}
+          location={postData.location}
+        />
+      </Stack>
 
-        {/* Comment Section */}
-        <Stack sx={{ px: 8, pb: 5 }}>
-          <Typography variant='h5' sx={{ py: 2 }}>
-            Comments
-          </Typography>
-          <TextField
-            variant='filled'
-            placeholder='Write a comment'
-            size='small'
-          ></TextField>
-          <Button variant='contained' sx={{ mt: 2 }}>
-            Add Comment
-          </Button>
-        </Stack>
-        {/* TODO: Create Comment component later */}
-      </Dialog>
+      {/* Comment Section */}
+      <Stack sx={{ px: 8, pb: 5 }}>
+        <Typography variant='h5' sx={{ py: 2 }}>
+          Comments
+        </Typography>
+        <TextField
+          variant='filled'
+          placeholder='Write a comment'
+          size='small'
+        ></TextField>
+        <Button variant='contained' sx={{ mt: 2 }}>
+          Add Comment
+        </Button>
+      </Stack>
+      {/* TODO: Create Comment component later */}
     </>
   );
 }

--- a/client/src/components/ViewPostDialog.tsx
+++ b/client/src/components/ViewPostDialog.tsx
@@ -233,15 +233,15 @@ function LocationHandler(props: {
 export default function ViewPostDialog() {
   const [postData, setData] = React.useState({} as PostUser);
   const [isAuthor, setIsAuthor] = React.useState(false);
-  const [error, toggleError] = React.useState(false);
   const userContext = React.useContext(UserContext);
   const { postid } = useParams();
   const navigate = useNavigate();
+  const [error, toggleError] = React.useState(false);
 
   /* Need to fetch the rest of the post data (or update it incase the post has changed) */
   const fetchData = () => {
     api
-      .fetchPost(postid ? postid : '')
+      .fetchPost(postid!)
       .then((res) => {
         if (res.data && res.data.data && res.data.data.result) {
           setData(res.data.data.result);
@@ -249,6 +249,8 @@ export default function ViewPostDialog() {
             setIsAuthor(userContext.data.id === res.data.data.result.User.id);
             toggleError(false);
           }
+        } else {
+          toggleError(true);
         }
       })
       .catch((err) => {
@@ -258,8 +260,7 @@ export default function ViewPostDialog() {
   };
 
   React.useEffect(() => {
-    // Fetch data (on initiual load)
-    // Prevent fetching again if an error occurred
+    // Fetch data (on initial load)
     if (!postData.User && !error) {
       fetchData();
     }
@@ -267,18 +268,29 @@ export default function ViewPostDialog() {
 
   React.useEffect(() => {
     /* Fetch incase data has changed / post was edited */
-    const interval = setInterval(() => {
-      fetchData();
-    }, 5000);
-    return () => clearInterval(interval);
+    if (!error) {
+      const interval = setInterval(() => {
+        fetchData();
+      }, 5000);
+      return () => clearInterval(interval);
+    }
   });
 
-
   if (error) {
-    return <><h1>The post you are looking for may have been deleted. </h1> <a href='/dashboard'>Go back</a> </>;
-  }
-  else if (!postData || !postData.User) {
-    return <h1>Loading..</h1>;
+    return (
+      <>
+        <Typography variant='h4'>
+          The post you requested does not exist.{' '}
+        </Typography>
+        <a href='/dashboard'>Return home?</a>
+      </>
+    );
+  } else if (!postData || !postData.User) {
+    return (
+      <>
+        <Typography variant='h4'>Loading</Typography>
+      </>
+    );
   }
 
   return (

--- a/client/src/containers/PostDashboard.tsx
+++ b/client/src/containers/PostDashboard.tsx
@@ -80,7 +80,6 @@ export default function PostDashboard() {
 
   return (
     <>
-      
       <Header />
       <main>
         <Container

--- a/client/src/containers/PostDashboard.tsx
+++ b/client/src/containers/PostDashboard.tsx
@@ -80,6 +80,7 @@ export default function PostDashboard() {
 
   return (
     <>
+      
       <Header />
       <main>
         <Container

--- a/server/controllers/v1/post.ts
+++ b/server/controllers/v1/post.ts
@@ -143,6 +143,7 @@ export default class PostController {
         'body',
         'thumbnail',
         'location',
+        'createdAt',
         'coords',
         'capacity',
         'feedbackScore',


### PR DESCRIPTION
Replaced the dialog-style popups with react routing. Post view and everything is the same, except opening a post routes to a new page.

The page URL is `website.com/<POSTID>`. 

Routing was necessary so that it can be used to embed post links into map view, and it also allows us to create shareable links to posts. 

This will also resolve #59 