### PR TITLE
Change PostPreview Style

### DIFF
--- a/client/src/components/PostPreview.tsx
+++ b/client/src/components/PostPreview.tsx
@@ -105,24 +105,23 @@ export default function PostPreview(props: { postUser: PostUserPreview }) {
           </Typography>
         </CardContent>
         <CardActions>
-          <Grid container sx={{ pl: 1 }} spacing={2}>
-            <Grid item sx={{ ml: 2 }} xs={3}>
+          <Grid container style={{textAlign: "center"}} spacing={2}>
+            <Grid item xs={4}>
               <ThumbUpIcon />
               <Typography>{props.postUser.likeCount}</Typography>
             </Grid>
-            <Grid item xs={3}>
-              <ChatBubbleIcon />
-              <Typography>0</Typography>
-            </Grid>
             {Number(props.postUser.capacity) > 0 ? (
-              <Grid item xs={3}>
+              <Grid item xs={4}>
                 <PeopleAltIcon />
-                <Typography>{props.postUser.usersCheckedIn}/{props.postUser.capacity}</Typography>
+                <Typography>{props.postUser.usersCheckedIn ? props.postUser.usersCheckedIn : 0}/{props.postUser.capacity}</Typography>
               </Grid>
             ) : (
               <> </>
             )}
-
+            <Grid item xs={4}>
+              <ChatBubbleIcon />
+              <Typography>{props.postUser.totalComments}</Typography>
+            </Grid>
             <Grid item md={12}>
               {tags}
             </Grid>

--- a/client/src/components/PostPreview.tsx
+++ b/client/src/components/PostPreview.tsx
@@ -105,7 +105,7 @@ export default function PostPreview(props: { postUser: PostUserPreview }) {
           </Typography>
         </CardContent>
         <CardActions>
-          <Grid container style={{textAlign: "center"}} spacing={2}>
+          <Grid container style={{ textAlign: 'center' }} spacing={2}>
             <Grid item xs={4}>
               <ThumbUpIcon />
               <Typography>{props.postUser.likeCount}</Typography>
@@ -113,7 +113,12 @@ export default function PostPreview(props: { postUser: PostUserPreview }) {
             {Number(props.postUser.capacity) > 0 ? (
               <Grid item xs={4}>
                 <PeopleAltIcon />
-                <Typography>{props.postUser.usersCheckedIn ? props.postUser.usersCheckedIn : 0}/{props.postUser.capacity}</Typography>
+                <Typography>
+                  {props.postUser.usersCheckedIn
+                    ? props.postUser.usersCheckedIn
+                    : 0}
+                  /{props.postUser.capacity}
+                </Typography>
               </Grid>
             ) : (
               <> </>

--- a/client/src/components/PostPreview.tsx
+++ b/client/src/components/PostPreview.tsx
@@ -3,16 +3,16 @@ import Card from '@mui/material/Card';
 import CardActions from '@mui/material/CardActions';
 import CardContent from '@mui/material/CardContent';
 import CardMedia from '@mui/material/CardMedia';
-import Stack from '@mui/material/Stack';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
+import ThumbUpIcon from '@mui/icons-material/ThumbUp';
+import PeopleAltIcon from '@mui/icons-material/PeopleAlt';
+import ChatBubbleIcon from '@mui/icons-material/ChatBubble';
 
 import GenerateTags from './Tags';
-import ViewPostDialog from './ViewPostDialog';
 
 import { PostUserPreview } from '../api/v1/index';
 import { useNavigate } from 'react-router-dom';
-import Button from '@mui/material/Button';
 
 /**
  * Return a string of the date relative to now in minutes, hours or days. If the date
@@ -45,26 +45,36 @@ function relativeTime(date: Date) {
   }
 }
 
-export default function PostPreview(props: {
-  postUser: PostUserPreview;
-  setOpenedPost: React.Dispatch<React.SetStateAction<boolean>>;
-}) {
+export default function PostPreview(props: { postUser: PostUserPreview }) {
   // generate tags (if the post has any)
   const tags = (
     <GenerateTags
+      spacing={4}
       tags={props.postUser.Tags ? props.postUser.Tags.map((t) => t.text) : []}
     />
   );
-
+  const [isHovered, setHover] = React.useState(false);
   const navigate = useNavigate();
 
   return (
     <Grid data-testid='test-postpreview' item xs={12} sm={6} md={4} lg={4}>
       <Card
+        raised={isHovered}
         sx={{
           display: 'flex',
           flexDirection: 'column',
           maxWidth: 500,
+          cursor: 'pointer',
+          borderRadius: '10px',
+        }}
+        onClick={() => {
+          navigate(`/${props.postUser.id}`);
+        }}
+        onMouseEnter={() => {
+          setHover(true);
+        }}
+        onMouseLeave={() => {
+          setHover(false);
         }}
       >
         <CardMedia
@@ -72,7 +82,10 @@ export default function PostPreview(props: {
           //TODO: once we set this up src={props.postUser.thumbnail}
           src='https://i.imgur.com/8EYKtwP.png'
           alt='placeholder'
-          sx={{ maxWidth: '500px', maxHeight: '145px' }}
+          sx={{
+            maxWidth: '500px',
+            maxHeight: '145px',
+          }}
         />
         <CardContent sx={{ flexGrow: 1, mb: -2 }}>
           <Typography
@@ -94,19 +107,29 @@ export default function PostPreview(props: {
           </Typography>
         </CardContent>
         <CardActions>
-          <Stack sx={{ pl: 1 }}>
-            <Button
-              data-testid='test-btn-preview'
-              variant='outlined'
-              onClick={() => {
-                navigate(`/${props.postUser.id}`);
-              }}
-              sx={{ mb: 3 }}
-            >
-              Read More
-            </Button>
-            {tags}
-          </Stack>
+          <Grid container sx={{ pl: 1 }} spacing={2}>
+            <Grid item sx={{ ml: 2 }} xs={3}>
+              <ThumbUpIcon />
+              <Typography>{props.postUser.likeCount}</Typography>
+            </Grid>
+            <Grid item xs={3}>
+              <ChatBubbleIcon />
+              <Typography>0</Typography>
+            </Grid>
+            {/* TODO: Update type when checkins is merged */}
+            {Number((props.postUser as any).capacity) > 0 ? (
+              <Grid item xs={3}>
+                <PeopleAltIcon />
+                <Typography>0/{(props.postUser as any).capacity} </Typography>
+              </Grid>
+            ) : (
+              <> </>
+            )}
+
+            <Grid item md={12}>
+              {tags}
+            </Grid>
+          </Grid>
         </CardActions>
       </Card>
     </Grid>

--- a/client/src/components/PostPreview.tsx
+++ b/client/src/components/PostPreview.tsx
@@ -49,7 +49,7 @@ export default function PostPreview(props: { postUser: PostUserPreview }) {
   // generate tags (if the post has any)
   const tags = (
     <GenerateTags
-      spacing={4}
+      space={4}
       tags={props.postUser.Tags ? props.postUser.Tags.map((t) => t.text) : []}
     />
   );

--- a/client/src/components/Tags.tsx
+++ b/client/src/components/Tags.tsx
@@ -7,9 +7,9 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 
 /* Generate pre-formatted TagItems based on an array of provided tags */
-export default function GenerateTags(props: { tags: string[], spacing?: number }) {
+export default function GenerateTags(props: { tags: string[], space?: number }) {
   return (
-    <Stack direction='row' spacing={props.spacing ? props.spacing: 1} style={{ alignItems: 'center' }}>
+    <Stack direction='row' spacing={props.space ? props.space : 1} style={{ alignItems: 'center' }}>
       {props.tags.map((tag: string) => (
         <Tag tag={tag} key={tag} />
       ))}

--- a/client/src/components/Tags.tsx
+++ b/client/src/components/Tags.tsx
@@ -7,9 +7,9 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 
 /* Generate pre-formatted TagItems based on an array of provided tags */
-export default function GenerateTags(props: { tags: string[] }) {
+export default function GenerateTags(props: { tags: string[], spacing?: number }) {
   return (
-    <Stack direction='row' spacing={1} style={{ alignItems: 'center' }}>
+    <Stack direction='row' spacing={props.spacing ? props.spacing: 1} style={{ alignItems: 'center' }}>
       {props.tags.map((tag: string) => (
         <Tag tag={tag} key={tag} />
       ))}

--- a/client/src/containers/PostDashboard.test.tsx
+++ b/client/src/containers/PostDashboard.test.tsx
@@ -11,7 +11,6 @@ function fakePostPreview(
   title: string,
   body: string,
   createdAt: string,
-  tags?: string[]
 ): PostUserPreview {
   return {
     id: (Math.random() * 100).toString(),
@@ -74,9 +73,6 @@ describe('Post Preview correctly displayed', () => {
     render(
       <PostPreview
         postUser={post}
-        setOpenedPost={
-          {} as any as React.Dispatch<React.SetStateAction<boolean>>
-        }
       />
     );
 
@@ -102,9 +98,6 @@ describe('Post Preview correctly displayed', () => {
     render(
       <PostPreview
         postUser={post}
-        setOpenedPost={
-          {} as any as React.Dispatch<React.SetStateAction<boolean>>
-        }
       />
     );
 
@@ -128,9 +121,6 @@ describe('Post Preview correctly displayed', () => {
     render(
       <PostPreview
         postUser={post}
-        setOpenedPost={
-          {} as any as React.Dispatch<React.SetStateAction<boolean>>
-        }
       />
     );
 
@@ -154,9 +144,6 @@ describe('Post Preview correctly displayed', () => {
     render(
       <PostPreview
         postUser={post}
-        setOpenedPost={
-          {} as any as React.Dispatch<React.SetStateAction<boolean>>
-        }
       />
     );
 
@@ -175,9 +162,6 @@ describe('Post Preview correctly displayed', () => {
           `${'b'.repeat(300)}`,
           '2021-11-22T01:41:01.112Z'
         )}
-        setOpenedPost={
-          {} as any as React.Dispatch<React.SetStateAction<boolean>>
-        }
       />
     );
 

--- a/client/src/containers/PostDashboard.tsx
+++ b/client/src/containers/PostDashboard.tsx
@@ -67,7 +67,6 @@ function RecentPosts(props: {
         <PostPreview
           key={data.id}
           postUser={data}
-          setOpenedPost={setOpenedPost}
         />
       ))}
     </>


### PR DESCRIPTION
Closes #92 

- Remove 'Read more' button, post opens when you click anywhere on the card
- Shadow effect when mouse is over the card
- Show capacity/numbers checked in, likes, and comments on the preview card. (Capacity is completely hidden if the post has max capacity of 0)

Requires #70 to be merged. (Need to test it after to ensure comment count is accurately reflected)

![image](https://user-images.githubusercontent.com/66292154/147792868-54ff817f-f09b-45e8-99bf-80985778e875.png)

When mouse is over the card (shadow):
![image](https://user-images.githubusercontent.com/66292154/147792925-b4377279-f466-4fd2-97c4-ae00b5c39da0.png)
