### PR TITLE
Update `getPost` to properly return `404` on error

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -93,7 +93,7 @@ function App() {
         <Routes>
           <Route path='/' element={<AuthContainer />} />
           <Route path='/dashboard' element={<ProtectedRoute destination={<PostDashboard />} />} />
-          <Route path='post-:postid' element={<ProtectedRoute destination={<ViewPostDialog />} />}  /> 
+          <Route path='/post-:postid' element={<ProtectedRoute destination={<ViewPostDialog />} />}  /> 
           <Route path='/confirm-account' element={<EmailConfirmContainer />} />
           <Route path='/password-reset' element={<PassResetContainer />} />
         </Routes>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -93,7 +93,7 @@ function App() {
         <Routes>
           <Route path='/' element={<AuthContainer />} />
           <Route path='/dashboard' element={<ProtectedRoute destination={<PostDashboard />} />} />
-          <Route path=':postid' element={<ProtectedRoute destination={<ViewPostDialog />} />}  /> 
+          <Route path='post-:postid' element={<ProtectedRoute destination={<ViewPostDialog />} />}  /> 
           <Route path='/confirm-account' element={<EmailConfirmContainer />} />
           <Route path='/password-reset' element={<PassResetContainer />} />
         </Routes>

--- a/client/src/components/PostPreview.tsx
+++ b/client/src/components/PostPreview.tsx
@@ -68,7 +68,7 @@ export default function PostPreview(props: { postUser: PostUserPreview }) {
           borderRadius: '10px',
         }}
         onClick={() => {
-          navigate(`/${props.postUser.id}`);
+          navigate(`/post-${props.postUser.id}`);
         }}
         onMouseEnter={() => {
           setHover(true);

--- a/client/src/components/ViewPostDialog.tsx
+++ b/client/src/components/ViewPostDialog.tsx
@@ -499,7 +499,7 @@ export default function ViewPostDialog() {
   });
 
   if (error) {
-    navigate('/404');
+    window.location.replace('/404');
     return <></>;
   } else if (!postData || !postData.User) {
     return (

--- a/client/src/components/ViewPostDialog.tsx
+++ b/client/src/components/ViewPostDialog.tsx
@@ -499,14 +499,8 @@ export default function ViewPostDialog() {
   });
 
   if (error) {
-    return (
-      <>
-        <Typography variant='h4'>
-          The post you requested does not exist.{' '}
-        </Typography>
-        <a href='/dashboard'>Return home?</a>
-      </>
-    );
+    navigate('/404');
+    return <></>;
   } else if (!postData || !postData.User) {
     return (
       <>

--- a/server/controllers/v1/post.ts
+++ b/server/controllers/v1/post.ts
@@ -405,71 +405,77 @@ export default class PostController {
     status: number;
     data: { result?: PostUser; message?: string };
   }> {
-    const data = (await this.postsRepo.findByPk(postID, {
-      attributes: [
-        'id',
-        'title',
-        'body',
-        'thumbnail',
-        'location',
-        'createdAt',
-        'coords',
-        'capacity',
-        'feedbackScore',
-        'UserId',
-        [
-          sequelize.literal(
-            `(SELECT COUNT(*) FROM "UserPostLikes" as "Likes" WHERE "Likes"."postID" = "Post"."id")`
-          ),
-          'likeCount',
-        ],
-        [
-          sequelize.literal(
+    let data: PostUser | undefined = undefined;
+
+    try {
+      data = (await this.postsRepo.findByPk(postID, {
+        attributes: [
+          'id',
+          'title',
+          'body',
+          'thumbnail',
+          'location',
+          'createdAt',
+          'coords',
+          'capacity',
+          'feedbackScore',
+          'UserId',
+          [
+            sequelize.literal(
+              `(SELECT COUNT(*) FROM "UserPostLikes" as "Likes" WHERE "Likes"."postID" = "Post"."id")`
+            ),
+            'likeCount',
+          ],
+          [
+            sequelize.literal(
+              // https://sequelize.org/master/class/lib/sequelize.js~Sequelize.html#instance-method-escape
+              `(
+                SELECT COUNT(*) FROM "UserPostLikes" as "Likes" 
+                WHERE "Likes"."postID" = "Post"."id" 
+                  AND "Likes"."userID" = ${db.sequelize.escape(`${userID}`)}
+              )`
+            ),
+            'doesUserLike',
+          ],
+          [
+            sequelize.literal(
+              `(SELECT COUNT(*) FROM "UserCheckins" as "Checkin" 
+                  WHERE "Checkin"."postID" = "Post"."id" AND "Checkin"."userID" = ${db.sequelize.escape(
+                    `${userID}`
+                  )})`
+            ),
+            'isUserCheckedIn',
+          ],
+          [
+            sequelize.literal(
+              `(SELECT COUNT(*) FROM "UserCheckins" as "Checkin" 
+                  WHERE "Checkin"."postID" = "Post"."id")`
+            ),
+            'usersCheckedIn',
+          ],
+          [
             // https://sequelize.org/master/class/lib/sequelize.js~Sequelize.html#instance-method-escape
-            `(
-              SELECT COUNT(*) FROM "UserPostLikes" as "Likes" 
-              WHERE "Likes"."postID" = "Post"."id" 
-                AND "Likes"."userID" = ${db.sequelize.escape(`${userID}`)}
-            )`
-          ),
-          'doesUserLike',
-        ],
-        [
-          sequelize.literal(
-            `(SELECT COUNT(*) FROM "UserCheckins" as "Checkin" 
-                WHERE "Checkin"."postID" = "Post"."id" AND "Checkin"."userID" = ${db.sequelize.escape(
+            `(SELECT COUNT(*) FROM "UserReports" as "Reports" 
+                WHERE "Reports"."postID" = "Post"."id" AND "Reports"."userID" = ${db.sequelize.escape(
                   `${userID}`
-                )})`
-          ),
-          'isUserCheckedIn',
+                )})`,
+            'didUserReport',
+          ],
         ],
-        [
-          sequelize.literal(
-            `(SELECT COUNT(*) FROM "UserCheckins" as "Checkin" 
-                WHERE "Checkin"."postID" = "Post"."id")`
-          ),
-          'usersCheckedIn',
+        include: [
+          {
+            model: db.User,
+            attributes: ['firstName', 'lastName', 'userName'],
+          },
+          {
+            model: db.Tag,
+            attributes: ['text'],
+          },
         ],
-        [
-          // https://sequelize.org/master/class/lib/sequelize.js~Sequelize.html#instance-method-escape
-          `(SELECT COUNT(*) FROM "UserReports" as "Reports" 
-              WHERE "Reports"."postID" = "Post"."id" AND "Reports"."userID" = ${db.sequelize.escape(
-                `${userID}`
-              )})`,
-          'didUserReport',
-        ],
-      ],
-      include: [
-        {
-          model: db.User,
-          attributes: ['firstName', 'lastName', 'userName'],
-        },
-        {
-          model: db.Tag,
-          attributes: ['text'],
-        },
-      ],
-    })) as PostUser;
+      })) as PostUser;
+    } catch (err) {
+      console.error(`Find Post Error ${err}`);
+    }
 
     if (!data) {
       return {
@@ -477,6 +483,7 @@ export default class PostController {
         data: { message: `Post ${postID} could not be found` },
       };
     }
+
     const result = {
       status: 200,
       data: { result: data },


### PR DESCRIPTION
Fetching an invalid post, or one that was previously deleted, would not properly return `404` error and instead just timeout after a few mins. I fixed this by wrapping the DB query in a try catch.

On the frontend page URL was adjusted to be `post-postid` instead of `/postid` (I wanted to do `/posts/id` but this was causing issues with axios).

After these changes, going to an invalid post, or viewing a post that gets deleted, will redirect to the `/404` error page.